### PR TITLE
Add option to create a parameter file

### DIFF
--- a/.github/workflows/run_pipeline.yaml
+++ b/.github/workflows/run_pipeline.yaml
@@ -2,28 +2,36 @@ name: Turtle Nest CI pipeline
 on: [pull_request]
 
 jobs:
+  build-humble:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build Docker Image
+        run: docker compose -f docker/docker-compose.yaml build
+
   test-humble:
     runs-on: ubuntu-latest
+    needs: build-humble
     steps:
       - uses: actions/checkout@v4
       - name: Test Humble
         run: docker compose -f docker/docker-compose.yaml run --build test
 
-  test-iron:
+  build-test-iron:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Test Iron
         run: docker compose -f docker/docker-compose.yaml run --build test-iron
 
-  test-jazzy:
+  build-test-jazzy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Test Jazzy
         run: docker compose -f docker/docker-compose.yaml run --build test-jazzy
 
-  test-rolling:
+  build-test-rolling:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -32,6 +40,7 @@ jobs:
 
   colcon-test-rolling:
     runs-on: ubuntu-latest
+    needs: build-test-rolling
     steps:
       - uses: actions/checkout@v4
       - name: Run Colcon Test Rolling
@@ -39,6 +48,7 @@ jobs:
 
   colcon-test-humble:
     runs-on: ubuntu-latest
+    needs: build-humble
     steps:
       - uses: actions/checkout@v4
       - name: Run Colcon Test Humble

--- a/.github/workflows/run_pipeline.yaml
+++ b/.github/workflows/run_pipeline.yaml
@@ -2,54 +2,36 @@ name: Turtle Nest CI pipeline
 on: [pull_request]
 
 jobs:
-  build-humble:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Build Docker Image
-        run: docker compose -f docker/docker-compose.yaml build
-
   test-humble:
     runs-on: ubuntu-latest
-    needs: build-humble
     steps:
       - uses: actions/checkout@v4
+      - name: Build Humble Docker Image
+        run: docker compose -f docker/docker-compose.yaml build
       - name: Test Humble
         run: docker compose -f docker/docker-compose.yaml run --build test
+      - name: Run Colcon Test
+        run: docker compose -f docker/docker-compose.yaml run --build colcon-test-humble
 
-  build-test-iron:
+  test-iron:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Test Iron
         run: docker compose -f docker/docker-compose.yaml run --build test-iron
 
-  build-test-jazzy:
+  test-jazzy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Test Jazzy
         run: docker compose -f docker/docker-compose.yaml run --build test-jazzy
 
-  build-test-rolling:
+  test-rolling:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Test Rolling
         run: docker compose -f docker/docker-compose.yaml run --build test-rolling
-
-  colcon-test-rolling:
-    runs-on: ubuntu-latest
-    needs: build-test-rolling
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run Colcon Test Rolling
+      - name: Run Colcon Test
         run: docker compose -f docker/docker-compose.yaml run --build colcon-test-rolling
-
-  colcon-test-humble:
-    runs-on: ubuntu-latest
-    needs: build-humble
-    steps:
-      - uses: actions/checkout@v4
-      - name: Run Colcon Test Humble
-        run: docker compose -f docker/docker-compose.yaml run --build colcon-test-humble

--- a/.github/workflows/run_pipeline.yaml
+++ b/.github/workflows/run_pipeline.yaml
@@ -1,19 +1,45 @@
 name: Turtle Nest CI pipeline
 on: [pull_request]
+
 jobs:
-  build-test:
+  test-humble:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Build the Docker image
-      run: docker compose -f docker/docker-compose.yaml build
-    - name: Test Humble
-      run: docker compose -f docker/docker-compose.yaml run test
-    - name: Test Iron
-      run: docker compose -f docker/docker-compose.yaml run test-iron
-    - name: Test Jazzy
-      run: docker compose -f docker/docker-compose.yaml run test-jazzy
-    - name: Test Rolling
-      run: docker compose -f docker/docker-compose.yaml run test-rolling
-    - name: Run Colcon Test
-      run: docker compose -f docker/docker-compose.yaml run colcon-test
+      - uses: actions/checkout@v4
+      - name: Test Humble
+        run: docker compose -f docker/docker-compose.yaml run --build test
+
+  test-iron:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test Iron
+        run: docker compose -f docker/docker-compose.yaml run --build test-iron
+
+  test-jazzy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test Jazzy
+        run: docker compose -f docker/docker-compose.yaml run --build test-jazzy
+
+  test-rolling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Test Rolling
+        run: docker compose -f docker/docker-compose.yaml run --build test-rolling
+
+  colcon-test-rolling:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Colcon Test Rolling
+        run: docker compose -f docker/docker-compose.yaml run --build colcon-test-rolling
+
+  colcon-test-humble:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run Colcon Test Humble
+        run: docker compose -f docker/docker-compose.yaml run --build colcon-test-humble

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,15 +22,13 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Make default shell in Dockerfile bash instead of sh
 SHELL ["/bin/bash", "-c"]
 
-# Setup cyclone DDS
-ENV RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
-
 # Install dependencies
 # ROS already comes with gtest, but not with libgmock. Install it
 RUN sudo apt-get update && \
     sudo apt-get install -y --no-install-recommends \
     libgmock-dev \
-    ros-${ROS_DISTRO}-rmw-cyclonedds-cpp \
+    nano \
+    htop \
     && sudo apt-get clean && \
     sudo rm -rf /var/lib/apt/lists/*
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
       args:
-          BASE_IMAGE: ros:humble
+          BASE_IMAGE: ros:jazzy
     container_name: turtle_nest
     stop_signal: SIGINT
     network_mode: host

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       context: ../
       dockerfile: docker/Dockerfile
       args:
-          BASE_IMAGE: ros:jazzy
+          BASE_IMAGE: ros:humble
     container_name: turtle_nest
     stop_signal: SIGINT
     network_mode: host
@@ -79,11 +79,21 @@ services:
     stdin_open: true
     tty: true
     command: /home/user/ros2_ws/src/turtle_nest_tests/build/turtle_nest_tests
-  
-  colcon-test:
+
+  # For running uncrustify to validate formatting
+  colcon-test-rolling:
     image: turtle_nest_rolling
-    container_name: turtle_nest_colcon_test
-    profiles: ["colcon-test"]
+    container_name: turtle_nest_colcon_test_rolling
+    profiles: ["colcon-test-rolling"]
+    stdin_open: true
+    tty: true
+    command: bash -c "cd /home/user/ros2_ws/ && colcon test && colcon test-result --all --verbose"
+
+  # Uncrustify gives different results in rolling and Humble. Run also in humble
+  colcon-test-humble:
+    image: turtle_nest
+    container_name: turtle_nest_colcon_test_humble
+    profiles: ["colcon-test-humble"]
     stdin_open: true
     tty: true
     command: bash -c "cd /home/user/ros2_ws/ && colcon test && colcon test-result --all --verbose"

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,12 +16,12 @@ services:
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - ${ROS2_WS:-${HOME}/ros2_ws/src}:/home/user/ros2_ws/src
-      # For development:
-      #- ../turtle_nest:/home/user/ros2_ws/src/turtle_nest
-      #- /home/user/ros2_ws/src/turtle_nest/build/ # Exclude build from being mounted
-      #- ../turtle_nest_tests:/home/user/ros2_ws/src/turtle_nest_tests
-      #- /home/user/ros2_ws/src/turtle_nest_tests/build/  # Exclude build from being mounted
       - ${HOME}/.config/TurtleNest:/home/user/.config/TurtleNest
+      # For development:
+      - ../turtle_nest:/home/user/ros2_ws/src/turtle_nest
+      - /home/user/ros2_ws/src/turtle_nest/build/ # Exclude build from being mounted
+      - ../turtle_nest_tests:/home/user/ros2_ws/src/turtle_nest_tests
+      - /home/user/ros2_ws/src/turtle_nest_tests/build/  # Exclude build from being mounted
     environment:
       - DISPLAY
       - QT_X11_NO_MITSHM=1

--- a/turtle_nest/CMakeLists.txt
+++ b/turtle_nest/CMakeLists.txt
@@ -15,8 +15,11 @@ set(SOURCES
   src/main.cpp
   src/mainwindow.cpp
   src/file_utils.cpp
+  src/generate_cmake.cpp
   src/generate_launch.cpp
   src/generate_node.cpp
+  src/generate_params.cpp
+  src/generate_setup_py.cpp
   src/rospkgcreator.cpp
   src/string_tools.cpp
 )

--- a/turtle_nest/include/turtle_nest/generate_cmake.h
+++ b/turtle_nest/include/turtle_nest/generate_cmake.h
@@ -19,7 +19,6 @@
 #define GENERATE_CMAKE_H
 
 #include <QString>
-#include <QDir>
 
 void modify_cmake_file(
   QString package_path, bool create_launch, bool create_config,

--- a/turtle_nest/include/turtle_nest/generate_cmake.h
+++ b/turtle_nest/include/turtle_nest/generate_cmake.h
@@ -21,6 +21,8 @@
 #include <QString>
 #include <QDir>
 
-void modify_cmake_file(QString package_path, bool create_launch, bool create_config, QString python_node_name);
+void modify_cmake_file(
+  QString package_path, bool create_launch, bool create_config,
+  QString python_node_name);
 
 #endif // GENERATE_CMAKE_H

--- a/turtle_nest/include/turtle_nest/generate_cmake.h
+++ b/turtle_nest/include/turtle_nest/generate_cmake.h
@@ -15,18 +15,12 @@
  * ------------------------------------------------------------------
 */
 
-#ifndef GENERATE_LAUNCH_H
-#define GENERATE_LAUNCH_H
+#ifndef GENERATE_CMAKE_H
+#define GENERATE_CMAKE_H
 
 #include <QString>
+#include <QDir>
 
+void modify_cmake_file(QString package_path, bool create_launch, bool create_config, QString python_node_name);
 
-void generate_launch_file(
-  QString workspace_path, QString package_name, QString launch_file_name, QString params_file_name,
-  QString node_name_cpp = "", QString node_name_python = "");
-QString generate_launch_text(QString package_name, QString node_name_cpp, QString node_name_python, QString params_file_name);
-void append_launch_to_cmake(QString c_make_path);
-void save_launch_file(QString file_name, QString launch_text);
-void append_launch_to_setup_py(QString setup_py_path, QString package_name);
-
-#endif // GENERATE_LAUNCH_H
+#endif // GENERATE_CMAKE_H

--- a/turtle_nest/include/turtle_nest/generate_launch.h
+++ b/turtle_nest/include/turtle_nest/generate_launch.h
@@ -24,7 +24,9 @@
 void generate_launch_file(
   QString workspace_path, QString package_name, QString launch_file_name, QString params_file_name,
   QString node_name_cpp = "", QString node_name_python = "");
-QString generate_launch_text(QString package_name, QString node_name_cpp, QString node_name_python, QString params_file_name);
+QString generate_launch_text(
+  QString package_name, QString node_name_cpp, QString node_name_python,
+  QString params_file_name);
 void append_launch_to_cmake(QString c_make_path);
 void save_launch_file(QString file_name, QString launch_text);
 void append_launch_to_setup_py(QString setup_py_path, QString package_name);

--- a/turtle_nest/include/turtle_nest/generate_node.h
+++ b/turtle_nest/include/turtle_nest/generate_node.h
@@ -20,7 +20,9 @@
 
 #include <QString>
 
-void generate_python_node(QString workspace_path, QString package_name, QString node_name, bool create_config);
+void generate_python_node(
+  QString workspace_path, QString package_name, QString node_name,
+  bool create_config);
 void create_init_file(QString node_dir);
 void add_exec_permissions(QString node_path);
 void generate_cpp_node(QString package_path, QString node_name, bool create_config);

--- a/turtle_nest/include/turtle_nest/generate_node.h
+++ b/turtle_nest/include/turtle_nest/generate_node.h
@@ -20,10 +20,9 @@
 
 #include <QString>
 
-void generate_python_node(QString workspace_path, QString package_name, QString node_name);
+void generate_python_node(QString workspace_path, QString package_name, QString node_name, bool create_config);
 void create_init_file(QString node_dir);
-void add_py_node_to_cmake(QString c_make_file_path, QString package_name, QString node_name);
 void add_exec_permissions(QString node_path);
-void generate_cpp_node(QString package_path, QString node_name);
+void generate_cpp_node(QString package_path, QString node_name, bool create_config);
 
 #endif // GENERATE_NODE_H

--- a/turtle_nest/include/turtle_nest/generate_params.h
+++ b/turtle_nest/include/turtle_nest/generate_params.h
@@ -15,18 +15,13 @@
  * ------------------------------------------------------------------
 */
 
-#ifndef GENERATE_LAUNCH_H
-#define GENERATE_LAUNCH_H
+#ifndef GENERATE_PARAMS_H
+#define GENERATE_PARAMS_H
 
 #include <QString>
+#include <QDir>
 
+void generate_params_file(QString package_path, QString params_file_name, QString node_name_cpp, QString node_name_python);
+QString get_params_content(QString node_name_cpp, QString node_name_python);
 
-void generate_launch_file(
-  QString workspace_path, QString package_name, QString launch_file_name, QString params_file_name,
-  QString node_name_cpp = "", QString node_name_python = "");
-QString generate_launch_text(QString package_name, QString node_name_cpp, QString node_name_python, QString params_file_name);
-void append_launch_to_cmake(QString c_make_path);
-void save_launch_file(QString file_name, QString launch_text);
-void append_launch_to_setup_py(QString setup_py_path, QString package_name);
-
-#endif // GENERATE_LAUNCH_H
+#endif // GENERATE_PARAMS_H

--- a/turtle_nest/include/turtle_nest/generate_params.h
+++ b/turtle_nest/include/turtle_nest/generate_params.h
@@ -19,7 +19,6 @@
 #define GENERATE_PARAMS_H
 
 #include <QString>
-#include <QDir>
 
 void generate_params_file(
   QString package_path, QString params_file_name, QString node_name_cpp,

--- a/turtle_nest/include/turtle_nest/generate_params.h
+++ b/turtle_nest/include/turtle_nest/generate_params.h
@@ -21,7 +21,9 @@
 #include <QString>
 #include <QDir>
 
-void generate_params_file(QString package_path, QString params_file_name, QString node_name_cpp, QString node_name_python);
+void generate_params_file(
+  QString package_path, QString params_file_name, QString node_name_cpp,
+  QString node_name_python);
 QString get_params_content(QString node_name_cpp, QString node_name_python);
 
 #endif // GENERATE_PARAMS_H

--- a/turtle_nest/include/turtle_nest/generate_setup_py.h
+++ b/turtle_nest/include/turtle_nest/generate_setup_py.h
@@ -15,18 +15,12 @@
  * ------------------------------------------------------------------
 */
 
-#ifndef GENERATE_LAUNCH_H
-#define GENERATE_LAUNCH_H
+#ifndef GENERATE_SETUP_PY_H
+#define GENERATE_SETUP_PY_H
 
 #include <QString>
+#include <QDir>
 
+void modify_setup_py(QString package_path, bool create_launch, bool create_config);
 
-void generate_launch_file(
-  QString workspace_path, QString package_name, QString launch_file_name, QString params_file_name,
-  QString node_name_cpp = "", QString node_name_python = "");
-QString generate_launch_text(QString package_name, QString node_name_cpp, QString node_name_python, QString params_file_name);
-void append_launch_to_cmake(QString c_make_path);
-void save_launch_file(QString file_name, QString launch_text);
-void append_launch_to_setup_py(QString setup_py_path, QString package_name);
-
-#endif // GENERATE_LAUNCH_H
+#endif // GENERATE_SETUP_PY_H

--- a/turtle_nest/include/turtle_nest/generate_setup_py.h
+++ b/turtle_nest/include/turtle_nest/generate_setup_py.h
@@ -19,7 +19,6 @@
 #define GENERATE_SETUP_PY_H
 
 #include <QString>
-#include <QDir>
 
 void modify_setup_py(QString package_path, bool create_launch, bool create_config);
 

--- a/turtle_nest/include/turtle_nest/mainwindow.h
+++ b/turtle_nest/include/turtle_nest/mainwindow.h
@@ -87,7 +87,15 @@ public:
 
   void on_launchNameInfoButton_clicked();
 
-private:
+  void on_checkboxCreateParams_toggled(bool checked);
+
+  void on_lineEditParamsName_textEdited(const QString &arg1);
+
+  void on_paramsNameInfoButton_clicked();
+
+  void on_lineEditParamsName_editingFinished();
+
+  private:
   Ui::MainWindow * ui;
 };
 

--- a/turtle_nest/include/turtle_nest/mainwindow.h
+++ b/turtle_nest/include/turtle_nest/mainwindow.h
@@ -89,13 +89,13 @@ public:
 
   void on_checkboxCreateParams_toggled(bool checked);
 
-  void on_lineEditParamsName_textEdited(const QString &arg1);
+  void on_lineEditParamsName_textEdited(const QString & arg1);
 
   void on_paramsNameInfoButton_clicked();
 
   void on_lineEditParamsName_editingFinished();
 
-  private:
+private:
   Ui::MainWindow * ui;
 };
 

--- a/turtle_nest/include/turtle_nest/rospkgcreator.h
+++ b/turtle_nest/include/turtle_nest/rospkgcreator.h
@@ -42,6 +42,7 @@ public:
   QString node_name_cpp = "";
   QString node_name_python = "";
   QString launch_name = "";
+  QString params_file_name = "";
   QString license = "TODO: License declaration";
   QString package_path;
 

--- a/turtle_nest/src/generate_cmake.cpp
+++ b/turtle_nest/src/generate_cmake.cpp
@@ -1,0 +1,61 @@
+/* ------------------------------------------------------------------
+ * Copyright 2024 Janne Karttunen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------
+*/
+
+#include "turtle_nest/generate_cmake.h"
+#include "turtle_nest/file_utils.h"
+
+void modify_cmake_file(QString package_path, bool create_launch, bool create_config, QString python_node_name){
+    QString c_make_path = QDir(package_path).filePath("CMakeLists.txt");
+    QString append_before_text = "ament_package()";
+    if (create_launch){
+        QString launch_append = R"(# Install launch files
+install(DIRECTORY
+  launch
+  DESTINATION share/${PROJECT_NAME}/
+)
+
+)";
+        append_to_file_before(c_make_path, launch_append, append_before_text);
+    }
+
+    if (create_config){
+        QString config_append = R"(# Install config files
+install(DIRECTORY
+  config
+  DESTINATION share/${PROJECT_NAME}/
+)
+
+)";
+        append_to_file_before(c_make_path, config_append, append_before_text);
+    }
+
+    if (!python_node_name.isEmpty()){
+        QString content(R"(# Install Python modules
+ament_python_install_package(${PROJECT_NAME})
+
+# Install Python executables
+install(PROGRAMS
+  ${PROJECT_NAME}/%1.py
+  DESTINATION lib/${PROJECT_NAME}
+  RENAME %1
+)
+
+)");
+        content = content.arg(python_node_name);
+        append_to_file_before(c_make_path, content, append_before_text);
+    }
+}

--- a/turtle_nest/src/generate_cmake.cpp
+++ b/turtle_nest/src/generate_cmake.cpp
@@ -17,6 +17,7 @@
 
 #include "turtle_nest/generate_cmake.h"
 #include "turtle_nest/file_utils.h"
+#include <QDir>
 
 void modify_cmake_file(
   QString package_path, bool create_launch, bool create_config,

--- a/turtle_nest/src/generate_cmake.cpp
+++ b/turtle_nest/src/generate_cmake.cpp
@@ -18,33 +18,39 @@
 #include "turtle_nest/generate_cmake.h"
 #include "turtle_nest/file_utils.h"
 
-void modify_cmake_file(QString package_path, bool create_launch, bool create_config, QString python_node_name){
-    QString c_make_path = QDir(package_path).filePath("CMakeLists.txt");
-    QString append_before_text = "ament_package()";
-    if (create_launch){
-        QString launch_append = R"(# Install launch files
+void modify_cmake_file(
+  QString package_path, bool create_launch, bool create_config,
+  QString python_node_name)
+{
+  QString c_make_path = QDir(package_path).filePath("CMakeLists.txt");
+  QString append_before_text = "ament_package()";
+  if (create_launch) {
+    QString launch_append =
+      R"(# Install launch files
 install(DIRECTORY
   launch
   DESTINATION share/${PROJECT_NAME}/
 )
 
 )";
-        append_to_file_before(c_make_path, launch_append, append_before_text);
-    }
+    append_to_file_before(c_make_path, launch_append, append_before_text);
+  }
 
-    if (create_config){
-        QString config_append = R"(# Install config files
+  if (create_config) {
+    QString config_append =
+      R"(# Install config files
 install(DIRECTORY
   config
   DESTINATION share/${PROJECT_NAME}/
 )
 
 )";
-        append_to_file_before(c_make_path, config_append, append_before_text);
-    }
+    append_to_file_before(c_make_path, config_append, append_before_text);
+  }
 
-    if (!python_node_name.isEmpty()){
-        QString content(R"(# Install Python modules
+  if (!python_node_name.isEmpty()) {
+    QString content(
+      R"(# Install Python modules
 ament_python_install_package(${PROJECT_NAME})
 
 # Install Python executables
@@ -55,7 +61,7 @@ install(PROGRAMS
 )
 
 )");
-        content = content.arg(python_node_name);
-        append_to_file_before(c_make_path, content, append_before_text);
-    }
+    content = content.arg(python_node_name);
+    append_to_file_before(c_make_path, content, append_before_text);
+  }
 }

--- a/turtle_nest/src/generate_launch.cpp
+++ b/turtle_nest/src/generate_launch.cpp
@@ -55,7 +55,7 @@ from ament_index_python.packages import get_package_share_directory
     config = os.path.join(
         get_package_share_directory('%1'),
         'config',
-        '%2',
+        '%2.yaml',
     )
 )")
     .arg(package_name, params_file_name);

--- a/turtle_nest/src/generate_launch.cpp
+++ b/turtle_nest/src/generate_launch.cpp
@@ -23,91 +23,60 @@
 #include <QMessageBox>
 #include <QDir>
 #include <QDebug>
-#include <sstream>
 
 
 void generate_launch_file(
-  QString workspace_path, QString package_name, QString launch_file_name,
-  QString node_name_cpp, QString node_name_python, BuildType build_type)
+  QString workspace_path, QString package_name, QString launch_file_name, QString params_file_name,
+  QString node_name_cpp, QString node_name_python)
 {
-  QString launch_text = generate_launch_text(package_name, node_name_cpp, node_name_python);
+  QString launch_text = generate_launch_text(package_name, node_name_cpp, node_name_python, params_file_name);
   QString launch_file_dir = QDir(workspace_path).filePath(package_name + "/launch/");
   QString launch_file_path = QDir(launch_file_dir).filePath(launch_file_name);
 
   create_directory(launch_file_dir);
   write_file(launch_file_path, launch_text);
   qInfo() << "Created launch file " << launch_file_path;
-
-  if (build_type == PYTHON) {
-    QString setup_py_path = QDir(workspace_path).filePath(package_name + "/setup.py");
-    append_launch_to_setup_py(setup_py_path, package_name);
-  } else {
-    QString c_make_file_path = QDir(workspace_path).filePath(package_name + "/CMakeLists.txt");
-    append_launch_to_cmake(c_make_file_path);
-  }
 }
 
-QString generate_launch_text(QString package_name, QString node_name_cpp, QString node_name_python)
+QString generate_launch_text(QString package_name, QString node_name_cpp, QString node_name_python, QString params_file_name)
 {
-  std::ostringstream oss;
-  oss <<
-    R"(from launch import LaunchDescription
+    QString config_import_block = params_file_name.isEmpty() ? "" : R"(import os
+from ament_index_python.packages import get_package_share_directory
+)";
+
+    QString config_block = params_file_name.isEmpty() ? "" : QString(R"(
+    config = os.path.join(
+        get_package_share_directory('%1'),
+        'config',
+        '%2',
+    )
+)").arg(package_name, params_file_name);
+
+    QString node_cpp_block = node_name_cpp.isEmpty() ? "" : QString(R"(
+        Node(
+            package='%1',
+            executable='%2',
+            name='%2',
+            output='screen',
+            parameters=[%3],
+        ),)").arg(package_name, node_name_cpp, config_block.isEmpty() ? "" : "config");
+
+    QString node_python_block = node_name_python.isEmpty() ? "" : QString(R"(
+        Node(
+            package='%1',
+            executable='%2',
+            name='%2',
+            output='screen',
+            parameters=[%3],
+        ),)").arg(package_name, node_name_python, config_block.isEmpty() ? "" : "config");
+
+    QString launch_content = QString(R"(%1
+from launch import LaunchDescription
 from launch_ros.actions import Node
 
-def generate_launch_description():
-    return LaunchDescription([)";
-
-  if (!node_name_cpp.isEmpty()) {
-    oss << R"(
-        Node(
-            package=')" << package_name.toStdString() << R"(',
-            executable=')" << node_name_cpp.toStdString() << R"(',
-            name=')" << node_name_cpp.toStdString() <<
-      R"(',
-            output='screen',
-        ),)";
-  }
-
-  if (!node_name_python.isEmpty()) {
-    oss << R"(
-        Node(
-            package=')" << package_name.toStdString() << R"(',
-            executable=')" << node_name_python.toStdString() << R"(',
-            name=')" << node_name_python.toStdString() <<
-      R"(',
-            output='screen',
-        ),)";
-  }
-  oss << R"(
+def generate_launch_description():%2
+    return LaunchDescription([%3%4
     ])
-)";
-
-  return QString::fromStdString(oss.str());
-}
-
-void append_launch_to_cmake(QString c_make_path)
-{
-  QString lines_to_append =
-    R"(# Install launch files
-install(DIRECTORY
-  launch
-  DESTINATION share/${PROJECT_NAME}/
-)
-
-)";
-  append_to_file_before(c_make_path, lines_to_append, "ament_package()");
-}
-
-void append_launch_to_setup_py(QString setup_py_path, QString package_name)
-{
-  QString lines_to_append(
-    "(os.path.join('share', '%1', 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),\n        ");
-  lines_to_append = lines_to_append.arg(package_name);
-  append_to_file_before(
-    setup_py_path, lines_to_append,
-    "('share/ament_index/resource_index/packages'");
-
-  QString imports("import os\n"
-    "from glob import glob\n");
-  append_to_file_before(setup_py_path, imports, "from setuptools import");
+)").arg(config_import_block, config_block, node_cpp_block, node_python_block);
+    return launch_content;
 }

--- a/turtle_nest/src/generate_launch.cpp
+++ b/turtle_nest/src/generate_launch.cpp
@@ -29,7 +29,9 @@ void generate_launch_file(
   QString workspace_path, QString package_name, QString launch_file_name, QString params_file_name,
   QString node_name_cpp, QString node_name_python)
 {
-  QString launch_text = generate_launch_text(package_name, node_name_cpp, node_name_python, params_file_name);
+  QString launch_text = generate_launch_text(
+    package_name, node_name_cpp, node_name_python,
+    params_file_name);
   QString launch_file_dir = QDir(workspace_path).filePath(package_name + "/launch/");
   QString launch_file_path = QDir(launch_file_dir).filePath(launch_file_name);
 
@@ -38,45 +40,57 @@ void generate_launch_file(
   qInfo() << "Created launch file " << launch_file_path;
 }
 
-QString generate_launch_text(QString package_name, QString node_name_cpp, QString node_name_python, QString params_file_name)
+QString generate_launch_text(
+  QString package_name, QString node_name_cpp, QString node_name_python,
+  QString params_file_name)
 {
-    QString config_import_block = params_file_name.isEmpty() ? "" : R"(import os
+  QString config_import_block =
+    params_file_name.isEmpty() ? "" :
+    R"(import os
 from ament_index_python.packages import get_package_share_directory
 )";
 
-    QString config_block = params_file_name.isEmpty() ? "" : QString(R"(
+  QString config_block = params_file_name.isEmpty() ? "" : QString(
+    R"(
     config = os.path.join(
         get_package_share_directory('%1'),
         'config',
         '%2',
     )
-)").arg(package_name, params_file_name);
+)")
+    .arg(package_name, params_file_name);
 
-    QString node_cpp_block = node_name_cpp.isEmpty() ? "" : QString(R"(
+  QString node_cpp_block = node_name_cpp.isEmpty() ? "" : QString(
+    R"(
         Node(
             package='%1',
             executable='%2',
             name='%2',
             output='screen',
             parameters=[%3],
-        ),)").arg(package_name, node_name_cpp, config_block.isEmpty() ? "" : "config");
+        ),)")
+    .arg(package_name, node_name_cpp, config_block.isEmpty() ? "" : "config");
 
-    QString node_python_block = node_name_python.isEmpty() ? "" : QString(R"(
+  QString node_python_block = node_name_python.isEmpty() ? "" : QString(
+    R"(
         Node(
             package='%1',
             executable='%2',
             name='%2',
             output='screen',
             parameters=[%3],
-        ),)").arg(package_name, node_name_python, config_block.isEmpty() ? "" : "config");
+        ),)")
+    .arg(package_name, node_name_python, config_block.isEmpty() ? "" : "config");
 
-    QString launch_content = QString(R"(%1
+  QString launch_content = QString(
+    R"(%1
 from launch import LaunchDescription
 from launch_ros.actions import Node
 
 def generate_launch_description():%2
     return LaunchDescription([%3%4
     ])
-)").arg(config_import_block, config_block, node_cpp_block, node_python_block);
-    return launch_content;
+)")
+    .arg(config_import_block, config_block, node_cpp_block, node_python_block);
+  return launch_content;
 }

--- a/turtle_nest/src/generate_node.cpp
+++ b/turtle_nest/src/generate_node.cpp
@@ -22,7 +22,9 @@
 #include <QDir>
 #include <QDebug>
 
-void generate_python_node(QString workspace_path, QString package_name, QString node_name, bool create_config)
+void generate_python_node(
+  QString workspace_path, QString package_name, QString node_name,
+  bool create_config)
 {
   QString package_path = QDir(workspace_path).filePath(package_name);
   QString node_dir = QDir(package_path).filePath(package_name);
@@ -30,7 +32,9 @@ void generate_python_node(QString workspace_path, QString package_name, QString 
 
   // Blocks to be added if parameter file was created
   QString param_import_block = !create_config ? "" : "from rclpy import Parameter\n";
-  QString param_declare_block = !create_config ? "" : R"(
+  QString param_declare_block =
+    !create_config ? "" :
+    R"(
         example_param = self.declare_parameter("example_param", Parameter.Type.STRING).value
         self.get_logger().info(f"Declared parameter 'example_param'. Value: {example_param}"))";
 
@@ -103,7 +107,9 @@ void add_exec_permissions(QString node_path)
 
 void generate_cpp_node(QString package_path, QString node_name, bool create_config)
 {
-    QString params_block = !create_config ? "" : R"(
+  QString params_block =
+    !create_config ? "" :
+    R"(
       this->declare_parameter<std::string>("example_param");
       std::string example_param = this->get_parameter("example_param").as_string();
       RCLCPP_INFO(this->get_logger(), "Declared parameter 'example_param'. Value: %s", example_param.c_str());

--- a/turtle_nest/src/generate_node.cpp
+++ b/turtle_nest/src/generate_node.cpp
@@ -30,12 +30,11 @@ void generate_python_node(
   QString node_dir = QDir(package_path).filePath(package_name);
   QString node_path = QDir(node_dir).filePath(node_name + ".py");
 
-  // Blocks to be added if parameter file was created
-  QString param_import_block = !create_config ? "" : "from rclpy import Parameter\n";
+  // Block to be added if parameter file was created
   QString param_declare_block =
     !create_config ? "" :
     R"(
-        example_param = self.declare_parameter("example_param", Parameter.Type.STRING).value
+        example_param = self.declare_parameter("example_param", "default_value").value
         self.get_logger().info(f"Declared parameter 'example_param'. Value: {example_param}"))";
 
   // Main content
@@ -43,7 +42,7 @@ void generate_python_node(
     R"(#!/usr/bin/env python3
 import rclpy
 from rclpy.node import Node
-%4
+
 from std_msgs.msg import String
 
 
@@ -71,7 +70,7 @@ def main(args=None):
 if __name__ == '__main__':
     main()
 )")
-    .arg(node_name, to_camel_case(node_name), param_declare_block, param_import_block);
+    .arg(node_name, to_camel_case(node_name), param_declare_block);
 
   create_directory(node_dir);
   write_file(node_path, content);
@@ -110,7 +109,7 @@ void generate_cpp_node(QString package_path, QString node_name, bool create_conf
   QString params_block =
     !create_config ? "" :
     R"(
-      this->declare_parameter<std::string>("example_param");
+      this->declare_parameter<std::string>("example_param", "default_value");
       std::string example_param = this->get_parameter("example_param").as_string();
       RCLCPP_INFO(this->get_logger(), "Declared parameter 'example_param'. Value: %s", example_param.c_str());
 )";

--- a/turtle_nest/src/generate_node.cpp
+++ b/turtle_nest/src/generate_node.cpp
@@ -22,24 +22,31 @@
 #include <QDir>
 #include <QDebug>
 
-void generate_python_node(QString workspace_path, QString package_name, QString node_name)
+void generate_python_node(QString workspace_path, QString package_name, QString node_name, bool create_config)
 {
   QString package_path = QDir(workspace_path).filePath(package_name);
   QString node_dir = QDir(package_path).filePath(package_name);
   QString node_path = QDir(node_dir).filePath(node_name + ".py");
 
+  // Blocks to be added if parameter file was created
+  QString param_import_block = !create_config ? "" : "from rclpy import Parameter\n";
+  QString param_declare_block = !create_config ? "" : R"(
+        example_param = self.declare_parameter("example_param", Parameter.Type.STRING).value
+        self.get_logger().info(f"Declared parameter 'example_param'. Value: {example_param}"))";
+
+  // Main content
   QString content = QString(
     R"(#!/usr/bin/env python3
 import rclpy
 from rclpy.node import Node
-
+%4
 from std_msgs.msg import String
 
 
 class %2(Node):
 
     def __init__(self):
-        super().__init__("%1")
+        super().__init__("%1")%3
         self.get_logger().info("Hello world from the Python node %1")
 
 
@@ -60,7 +67,7 @@ def main(args=None):
 if __name__ == '__main__':
     main()
 )")
-    .arg(node_name, to_camel_case(node_name));
+    .arg(node_name, to_camel_case(node_name), param_declare_block, param_import_block);
 
   create_directory(node_dir);
   write_file(node_path, content);
@@ -93,23 +100,14 @@ void add_exec_permissions(QString node_path)
   }
 }
 
-void add_py_node_to_cmake(QString c_make_file_path, QString package_name, QString node_name)
-{
-  QString content("# Install Python modules\n"
-    "ament_python_install_package(${PROJECT_NAME})\n\n"
-    "# Install Python executables\n"
-    "install(PROGRAMS\n"
-    "    %1/%2.py\n"
-    "DESTINATION lib/${PROJECT_NAME}\n"
-    "RENAME %2"
-    ")\n\n");
-  content = content.arg(package_name, node_name);
-  append_to_file_before(c_make_file_path, content, "ament_package()");
-}
 
-
-void generate_cpp_node(QString package_path, QString node_name)
+void generate_cpp_node(QString package_path, QString node_name, bool create_config)
 {
+    QString params_block = !create_config ? "" : R"(
+      this->declare_parameter<std::string>("example_param");
+      std::string example_param = this->get_parameter("example_param").as_string();
+      RCLCPP_INFO(this->get_logger(), "Declared parameter 'example_param'. Value: %s", example_param.c_str());
+)";
   // Uncrustify considers this as a single line. Skip.
   /* *INDENT-OFF* */
     QString content = QString(R"(#include "rclcpp/rclcpp.hpp"
@@ -120,7 +118,7 @@ class %2 : public rclcpp::Node
   public:
     %2()
     : Node("%1")
-    {
+    {%3
       RCLCPP_INFO(this->get_logger(), "Hello world from the C++ node %s", "%1");
     }
 };
@@ -131,7 +129,7 @@ int main(int argc, char * argv[])
   rclcpp::spin(std::make_shared<%2>());
   rclcpp::shutdown();
   return 0;
-})").arg(node_name, to_camel_case(node_name));
+})").arg(node_name, to_camel_case(node_name), params_block);
   /* *INDENT-ON* */
   write_file(QDir(package_path).filePath("src/" + node_name + ".cpp"), content);
 }

--- a/turtle_nest/src/generate_params.cpp
+++ b/turtle_nest/src/generate_params.cpp
@@ -17,6 +17,7 @@
 
 #include "turtle_nest/generate_params.h"
 #include "turtle_nest/file_utils.h"
+#include <QDir>
 
 void generate_params_file(
   QString package_path, QString params_file_name, QString node_name_cpp,

--- a/turtle_nest/src/generate_params.cpp
+++ b/turtle_nest/src/generate_params.cpp
@@ -1,0 +1,46 @@
+/* ------------------------------------------------------------------
+ * Copyright 2024 Janne Karttunen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------
+*/
+
+#include "turtle_nest/generate_params.h"
+#include "turtle_nest/file_utils.h"
+
+void generate_params_file(QString package_path, QString params_file_name, QString node_name_cpp, QString node_name_python){
+  QString params_file_dir = QDir(package_path).filePath("config");
+  QString params_file_path = QDir(params_file_dir).filePath(params_file_name);
+  create_directory(params_file_dir);
+  write_file(params_file_path, get_params_content(node_name_cpp, node_name_python));
+}
+
+QString get_params_content(QString node_name_cpp, QString node_name_python){
+    QString content = QString();
+    if (node_name_cpp != ""){
+        content = content + QString(R"(%1:
+  ros__parameters:
+    example_param: "abc"
+
+)").arg(node_name_cpp);;
+    }
+
+    if (node_name_python != ""){
+        content = content +  QString(R"(%1:
+  ros__parameters:
+    example_param: "abc"
+
+)").arg(node_name_python);
+    }
+    return content;
+}

--- a/turtle_nest/src/generate_params.cpp
+++ b/turtle_nest/src/generate_params.cpp
@@ -18,29 +18,33 @@
 #include "turtle_nest/generate_params.h"
 #include "turtle_nest/file_utils.h"
 
-void generate_params_file(QString package_path, QString params_file_name, QString node_name_cpp, QString node_name_python){
+void generate_params_file(
+  QString package_path, QString params_file_name, QString node_name_cpp,
+  QString node_name_python)
+{
   QString params_file_dir = QDir(package_path).filePath("config");
   QString params_file_path = QDir(params_file_dir).filePath(params_file_name);
   create_directory(params_file_dir);
   write_file(params_file_path, get_params_content(node_name_cpp, node_name_python));
 }
 
-QString get_params_content(QString node_name_cpp, QString node_name_python){
-    QString content = QString();
-    if (node_name_cpp != ""){
-        content = content + QString(R"(%1:
+QString get_params_content(QString node_name_cpp, QString node_name_python)
+{
+  QString content = QString();
+  if (node_name_cpp != "") {
+    content = content + QString(R"(%1:
   ros__parameters:
     example_param: "abc"
 
-)").arg(node_name_cpp);;
-    }
+)").arg(node_name_cpp);
+  }
 
-    if (node_name_python != ""){
-        content = content +  QString(R"(%1:
+  if (node_name_python != "") {
+    content = content + QString(R"(%1:
   ros__parameters:
     example_param: "abc"
 
 )").arg(node_name_python);
-    }
-    return content;
+  }
+  return content;
 }

--- a/turtle_nest/src/generate_setup_py.cpp
+++ b/turtle_nest/src/generate_setup_py.cpp
@@ -18,24 +18,27 @@
 #include "turtle_nest/generate_setup_py.h"
 #include "turtle_nest/file_utils.h"
 
-void modify_setup_py(QString package_path, bool create_launch, bool create_config){
-    QString setup_py_path = QDir(package_path).filePath("setup.py");
-    QString append_after = "('share/' + package_name, ['package.xml']),";
+void modify_setup_py(QString package_path, bool create_launch, bool create_config)
+{
+  QString setup_py_path = QDir(package_path).filePath("setup.py");
+  QString append_after = "('share/' + package_name, ['package.xml']),";
 
-    if (create_config){
-        QString config_content = "\n        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),";
-        append_to_file(setup_py_path, config_content, append_after);
-    }
+  if (create_config) {
+    QString config_content =
+      "\n        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),";
+    append_to_file(setup_py_path, config_content, append_after);
+  }
 
-    if (create_launch){
-        QString lines_to_append = "\n        (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),";
-        append_to_file(setup_py_path, lines_to_append, append_after);
-    }
+  if (create_launch) {
+    QString lines_to_append =
+      "\n        (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),";
+    append_to_file(setup_py_path, lines_to_append, append_after);
+  }
 
-    // Add imports if either launch or config was appended
-    if (create_launch || create_config){
-        QString imports("import os\n"
-                        "from glob import glob\n");
-        append_to_file_before(setup_py_path, imports, "from setuptools import");
-    }
+  // Add imports if either launch or config was appended
+  if (create_launch || create_config) {
+    QString imports("import os\n"
+      "from glob import glob\n");
+    append_to_file_before(setup_py_path, imports, "from setuptools import");
+  }
 }

--- a/turtle_nest/src/generate_setup_py.cpp
+++ b/turtle_nest/src/generate_setup_py.cpp
@@ -17,6 +17,7 @@
 
 #include "turtle_nest/generate_setup_py.h"
 #include "turtle_nest/file_utils.h"
+#include <QDir>
 
 void modify_setup_py(QString package_path, bool create_launch, bool create_config)
 {

--- a/turtle_nest/src/generate_setup_py.cpp
+++ b/turtle_nest/src/generate_setup_py.cpp
@@ -1,0 +1,41 @@
+/* ------------------------------------------------------------------
+ * Copyright 2024 Janne Karttunen
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ------------------------------------------------------------------
+*/
+
+#include "turtle_nest/generate_setup_py.h"
+#include "turtle_nest/file_utils.h"
+
+void modify_setup_py(QString package_path, bool create_launch, bool create_config){
+    QString setup_py_path = QDir(package_path).filePath("setup.py");
+    QString append_after = "('share/' + package_name, ['package.xml']),";
+
+    if (create_config){
+        QString config_content = "\n        (os.path.join('share', package_name, 'config'), glob('config/*.yaml')),";
+        append_to_file(setup_py_path, config_content, append_after);
+    }
+
+    if (create_launch){
+        QString lines_to_append = "\n        (os.path.join('share', package_name, 'launch'), glob(os.path.join('launch', '*launch.[pxy][yma]*'))),";
+        append_to_file(setup_py_path, lines_to_append, append_after);
+    }
+
+    // Add imports if either launch or config was appended
+    if (create_launch || create_config){
+        QString imports("import os\n"
+                        "from glob import glob\n");
+        append_to_file_before(setup_py_path, imports, "from setuptools import");
+    }
+}

--- a/turtle_nest/src/mainwindow.cpp
+++ b/turtle_nest/src/mainwindow.cpp
@@ -138,6 +138,10 @@ void MainWindow::on_createPackageButton_clicked()
     pkg_creator.launch_name = ui->lineEditLaunchName->text();
   }
 
+  if (ui->checkboxCreateParams->isChecked()) {
+      pkg_creator.params_file_name = ui->lineEditParamsName->text();
+  }
+
   // Row 0 is "No Licence", so it is not directly usable as the license.
   if (ui->licenseList->currentRow() != 0) {
     pkg_creator.license = get_license();
@@ -246,15 +250,16 @@ void MainWindow::on_lineEditNodeNamePython_textEdited(const QString & arg1)
 
 void MainWindow::on_checkboxCreateLaunch_toggled(bool checked)
 {
-  if (checked) {
-    ui->lineEditLaunchName->setText(ui->packageNameEdit->text() + "_launch");
-    ui->lineEditLaunchName->setEnabled(true);
-  } else {
-    ui->lineEditLaunchName->setEnabled(false);
-    ui->lineEditLaunchName->clear();
-    ui->launchSuffixWarnLabel->setVisible(false);
-  }
+    if (checked) {
+        ui->lineEditLaunchName->setText(ui->packageNameEdit->text() + "_launch");
+        ui->lineEditLaunchName->setEnabled(true);
+    } else {
+        ui->lineEditLaunchName->setEnabled(false);
+        ui->lineEditLaunchName->clear();
+        ui->launchSuffixWarnLabel->setVisible(false);
+    }
 }
+
 
 void MainWindow::on_lineEditLaunchName_textEdited(const QString & arg1)
 {
@@ -277,6 +282,34 @@ void MainWindow::on_lineEditLaunchName_editingFinished()
   }
 
 }
+
+
+void MainWindow::on_checkboxCreateParams_toggled(bool checked)
+{
+    if (checked) {
+        ui->lineEditParamsName->setText(ui->packageNameEdit->text() + "_params");
+        ui->lineEditParamsName->setEnabled(true);
+    } else {
+        ui->lineEditParamsName->setEnabled(false);
+        ui->lineEditParamsName->clear();
+    }
+}
+
+
+void MainWindow::on_lineEditParamsName_textEdited(const QString &arg1)
+{
+    QString autocorrected_text = autocorrect_line_edit(arg1, ui->lineEditParamsName);
+}
+
+
+void MainWindow::on_lineEditParamsName_editingFinished()
+{
+    // Use package name as the default params file name if the user tries to leave the field empty
+    if (ui->lineEditParamsName->text().length() < 1) {
+        ui->lineEditParamsName->setText(ui->packageNameEdit->text() + "_params");
+    }
+}
+
 
 QString MainWindow::get_license()
 {
@@ -331,7 +364,14 @@ void MainWindow::on_launchNameInfoButton_clicked()
   show_tooltip(ui->launchNameInfoButton);
 }
 
+
+void MainWindow::on_paramsNameInfoButton_clicked()
+{
+    show_tooltip(ui->paramsNameInfoButton);
+}
+
 void show_tooltip(QToolButton * button)
 {
   QToolTip::showText(button->mapToGlobal(QPoint(16, 16)), button->toolTip());
 }
+

--- a/turtle_nest/src/mainwindow.cpp
+++ b/turtle_nest/src/mainwindow.cpp
@@ -139,7 +139,7 @@ void MainWindow::on_createPackageButton_clicked()
   }
 
   if (ui->checkboxCreateParams->isChecked()) {
-      pkg_creator.params_file_name = ui->lineEditParamsName->text();
+    pkg_creator.params_file_name = ui->lineEditParamsName->text();
   }
 
   // Row 0 is "No Licence", so it is not directly usable as the license.
@@ -250,14 +250,14 @@ void MainWindow::on_lineEditNodeNamePython_textEdited(const QString & arg1)
 
 void MainWindow::on_checkboxCreateLaunch_toggled(bool checked)
 {
-    if (checked) {
-        ui->lineEditLaunchName->setText(ui->packageNameEdit->text() + "_launch");
-        ui->lineEditLaunchName->setEnabled(true);
-    } else {
-        ui->lineEditLaunchName->setEnabled(false);
-        ui->lineEditLaunchName->clear();
-        ui->launchSuffixWarnLabel->setVisible(false);
-    }
+  if (checked) {
+    ui->lineEditLaunchName->setText(ui->packageNameEdit->text() + "_launch");
+    ui->lineEditLaunchName->setEnabled(true);
+  } else {
+    ui->lineEditLaunchName->setEnabled(false);
+    ui->lineEditLaunchName->clear();
+    ui->launchSuffixWarnLabel->setVisible(false);
+  }
 }
 
 
@@ -286,28 +286,28 @@ void MainWindow::on_lineEditLaunchName_editingFinished()
 
 void MainWindow::on_checkboxCreateParams_toggled(bool checked)
 {
-    if (checked) {
-        ui->lineEditParamsName->setText(ui->packageNameEdit->text() + "_params");
-        ui->lineEditParamsName->setEnabled(true);
-    } else {
-        ui->lineEditParamsName->setEnabled(false);
-        ui->lineEditParamsName->clear();
-    }
+  if (checked) {
+    ui->lineEditParamsName->setText(ui->packageNameEdit->text() + "_params");
+    ui->lineEditParamsName->setEnabled(true);
+  } else {
+    ui->lineEditParamsName->setEnabled(false);
+    ui->lineEditParamsName->clear();
+  }
 }
 
 
-void MainWindow::on_lineEditParamsName_textEdited(const QString &arg1)
+void MainWindow::on_lineEditParamsName_textEdited(const QString & arg1)
 {
-    QString autocorrected_text = autocorrect_line_edit(arg1, ui->lineEditParamsName);
+  QString autocorrected_text = autocorrect_line_edit(arg1, ui->lineEditParamsName);
 }
 
 
 void MainWindow::on_lineEditParamsName_editingFinished()
 {
-    // Use package name as the default params file name if the user tries to leave the field empty
-    if (ui->lineEditParamsName->text().length() < 1) {
-        ui->lineEditParamsName->setText(ui->packageNameEdit->text() + "_params");
-    }
+  // Use package name as the default params file name if the user tries to leave the field empty
+  if (ui->lineEditParamsName->text().length() < 1) {
+    ui->lineEditParamsName->setText(ui->packageNameEdit->text() + "_params");
+  }
 }
 
 
@@ -367,11 +367,10 @@ void MainWindow::on_launchNameInfoButton_clicked()
 
 void MainWindow::on_paramsNameInfoButton_clicked()
 {
-    show_tooltip(ui->paramsNameInfoButton);
+  show_tooltip(ui->paramsNameInfoButton);
 }
 
 void show_tooltip(QToolButton * button)
 {
   QToolTip::showText(button->mapToGlobal(QPoint(16, 16)), button->toolTip());
 }
-

--- a/turtle_nest/src/mainwindow.ui
+++ b/turtle_nest/src/mainwindow.ui
@@ -282,7 +282,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
       <property name="geometry">
        <rect>
         <x>350</x>
-        <y>60</y>
+        <y>140</y>
         <width>211</width>
         <height>18</height>
        </rect>
@@ -298,7 +298,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
       <property name="geometry">
        <rect>
         <x>350</x>
-        <y>90</y>
+        <y>170</y>
         <width>201</width>
         <height>26</height>
        </rect>
@@ -314,7 +314,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
       <property name="geometry">
        <rect>
         <x>350</x>
-        <y>130</y>
+        <y>210</y>
         <width>251</width>
         <height>61</height>
        </rect>
@@ -333,7 +333,7 @@ li.checked::marker { content: &quot;\2612&quot;; }
       <property name="geometry">
        <rect>
         <x>560</x>
-        <y>90</y>
+        <y>170</y>
         <width>26</width>
         <height>26</height>
        </rect>
@@ -348,7 +348,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu Sans'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Launch file name needs to:&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• have only lowercase letters (a-z), digits (0-9), and underscores (_)&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• be at least two characters long&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• start with a letter&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;It is recommended to have &amp;quot;_launch&amp;quot; suffix for 'ros2 launch' to recognize the file for autocompletion&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
       </property>
@@ -505,7 +504,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu Sans'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Node name needs to:&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• have only lowercase letters (a-z), digits (0-9), and underscores (_)&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• be at least two characters long&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• start with a letter&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="styleSheet">
@@ -590,7 +588,6 @@ li.checked::marker { content: &quot;\2612&quot;; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu Sans'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Node name needs to:&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• have only lowercase letters (a-z), digits (0-9), and underscores (_)&lt;/p&gt;
-&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• be at least two characters long&lt;/p&gt;
 &lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• start with a letter&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="styleSheet">
@@ -625,6 +622,86 @@ li.checked::marker { content: &quot;\2612&quot;; }
         </layout>
        </item>
       </layout>
+     </widget>
+     <widget class="QCheckBox" name="checkboxCreateParams">
+      <property name="geometry">
+       <rect>
+        <x>350</x>
+        <y>60</y>
+        <width>211</width>
+        <height>18</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Create Parameter File</string>
+      </property>
+     </widget>
+     <widget class="QToolButton" name="paramsNameInfoButton">
+      <property name="geometry">
+       <rect>
+        <x>560</x>
+        <y>90</y>
+        <width>26</width>
+        <height>26</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;meta charset=&quot;utf-8&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+hr { height: 1px; border-width: 0; }
+li.unchecked::marker { content: &quot;\2610&quot;; }
+li.checked::marker { content: &quot;\2612&quot;; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu Sans'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Creates a YAML parameter file to store all the Node parameters.&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Parameter file name needs to:&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• have only lowercase letters (a-z), digits (0-9), and underscores (_)&lt;/p&gt;
+&lt;p style=&quot; margin-top:12px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;• start with a letter&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+      </property>
+      <property name="styleSheet">
+       <string notr="true">border: none;</string>
+      </property>
+      <property name="text">
+       <string>?</string>
+      </property>
+      <property name="icon">
+       <iconset resource="../resources.qrc">
+        <normaloff>:/images/img/info_icon_92px.png</normaloff>:/images/img/info_icon_92px.png</iconset>
+      </property>
+      <property name="iconSize">
+       <size>
+        <width>24</width>
+        <height>24</height>
+       </size>
+      </property>
+      <property name="popupMode">
+       <enum>QToolButton::DelayedPopup</enum>
+      </property>
+      <property name="toolButtonStyle">
+       <enum>Qt::ToolButtonIconOnly</enum>
+      </property>
+      <property name="autoRaise">
+       <bool>false</bool>
+      </property>
+     </widget>
+     <widget class="QLineEdit" name="lineEditParamsName">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>350</x>
+        <y>90</y>
+        <width>201</width>
+        <height>26</height>
+       </rect>
+      </property>
+      <property name="focusPolicy">
+       <enum>Qt::StrongFocus</enum>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+      </property>
      </widget>
     </widget>
     <widget class="QWidget" name="page_3">

--- a/turtle_nest/src/rospkgcreator.cpp
+++ b/turtle_nest/src/rospkgcreator.cpp
@@ -56,7 +56,7 @@ void RosPkgCreator::create_package() const
   // Generate launch file
   if (create_launch) {
     generate_launch_file(
-      workspace_path, package_name, launch_name + ".py", params_file_name + ".yaml", node_name_cpp,
+      workspace_path, package_name, launch_name + ".py", params_file_name, node_name_cpp,
       node_name_python);
   }
 

--- a/turtle_nest/src/rospkgcreator.cpp
+++ b/turtle_nest/src/rospkgcreator.cpp
@@ -41,7 +41,7 @@ void RosPkgCreator::create_package() const
 
   // Overwrite the simple hello world nodes with more advanced ones
   if (!node_name_python.isEmpty()) {
-      generate_python_node(workspace_path, package_name, node_name_python, create_config);
+    generate_python_node(workspace_path, package_name, node_name_python, create_config);
   }
   if (!node_name_cpp.isEmpty()) {
     generate_cpp_node(package_path, node_name_cpp, create_config);
@@ -61,15 +61,15 @@ void RosPkgCreator::create_package() const
   }
 
   // Generate parameters file
-  if (create_config){
-      generate_params_file(package_path, params_file_name + ".yaml", node_name_cpp, node_name_python);
+  if (create_config) {
+    generate_params_file(package_path, params_file_name + ".yaml", node_name_cpp, node_name_python);
   }
 
   // Modify setup.py or CMakeLists
   if (build_type == PYTHON) {
-      modify_setup_py(package_path, create_launch, create_config);
+    modify_setup_py(package_path, create_launch, create_config);
   } else {
-      modify_cmake_file(package_path, create_launch, create_config, node_name_python);
+    modify_cmake_file(package_path, create_launch, create_config, node_name_python);
   }
 
   // Add watermark

--- a/turtle_nest/src/rospkgcreator.cpp
+++ b/turtle_nest/src/rospkgcreator.cpp
@@ -17,8 +17,11 @@
 
 #include "turtle_nest/rospkgcreator.h"
 #include "turtle_nest/file_utils.h"
+#include "turtle_nest/generate_cmake.h"
 #include "turtle_nest/generate_launch.h"
 #include "turtle_nest/generate_node.h"
+#include "turtle_nest/generate_params.h"
+#include "turtle_nest/generate_setup_py.h"
 #include "turtle_nest/string_tools.h"
 
 #include <QDir>
@@ -33,29 +36,40 @@ void RosPkgCreator::create_package() const
   QStringList command = create_command();
   run_command(command);
 
+  bool create_launch = (launch_name != "");
+  bool create_config = (params_file_name != "");
+
   // Overwrite the simple hello world nodes with more advanced ones
   if (!node_name_python.isEmpty()) {
-    generate_python_node(workspace_path, package_name, node_name_python);
+      generate_python_node(workspace_path, package_name, node_name_python, create_config);
   }
   if (!node_name_cpp.isEmpty()) {
-    generate_cpp_node(package_path, node_name_cpp);
+    generate_cpp_node(package_path, node_name_cpp, create_config);
   }
 
-  // Setup Python stuff if using both Cpp and Python
+  // Create Python init file if creating CPP and Python package
   if (build_type == CPP_AND_PYTHON) {
     QString node_dir = QDir(package_path).filePath(package_name);
     create_init_file(node_dir);
-    if (!node_name_python.isEmpty()) {
-      QString c_make_file_path = QDir(package_path).filePath("CMakeLists.txt");
-      add_py_node_to_cmake(c_make_file_path, package_name, node_name_python);
-      qInfo() << "Python Node added to CMakeLists.txt";
-    }
   }
 
-  if (launch_name != "") {
+  // Generate launch file
+  if (create_launch) {
     generate_launch_file(
-      workspace_path, package_name, launch_name + ".py", node_name_cpp,
-      node_name_python, build_type);
+      workspace_path, package_name, launch_name + ".py", params_file_name + ".yaml", node_name_cpp,
+      node_name_python);
+  }
+
+  // Generate parameters file
+  if (create_config){
+      generate_params_file(package_path, params_file_name + ".yaml", node_name_cpp, node_name_python);
+  }
+
+  // Modify setup.py or CMakeLists
+  if (build_type == PYTHON) {
+      modify_setup_py(package_path, create_launch, create_config);
+  } else {
+      modify_cmake_file(package_path, create_launch, create_config, node_name_python);
   }
 
   // Add watermark

--- a/turtle_nest/turtle_nest.pro
+++ b/turtle_nest/turtle_nest.pro
@@ -10,8 +10,11 @@ CONFIG += c++17
 
 SOURCES += \
     src/file_utils.cpp \
+    src/generate_cmake.cpp \
     src/generate_launch.cpp \
     src/generate_node.cpp \
+    src/generate_params.cpp \
+    src/generate_setup_py.cpp \
     src/main.cpp \
     src/mainwindow.cpp \
     src/rospkgcreator.cpp \
@@ -20,11 +23,14 @@ SOURCES += \
 HEADERS += \
     include/turtle_nest/build_type_enum.h \
     include/turtle_nest/file_utils.h \
+    include/turtle_nest/generate_cmake.h \
     include/turtle_nest/generate_launch.h \
     include/turtle_nest/generate_node.h \
+    include/turtle_nest/generate_setup_py.h \
     include/turtle_nest/mainwindow.h \
     include/turtle_nest/rospkgcreator.h \
-    include/turtle_nest/string_tools.h
+    include/turtle_nest/string_tools.h \
+    include/turtle_nest/generate_params.h
 
 FORMS += \
     src/mainwindow.ui

--- a/turtle_nest_tests/tst_generate_node.cpp
+++ b/turtle_nest_tests/tst_generate_node.cpp
@@ -34,7 +34,7 @@ TEST(generate_node, happy_flow)
     create_directory(package_path);
     write_file(mock_cmake_path, "ament_package()");
 
-    generate_python_node(temp_dir.path(), "package_1", "node_123");
+    generate_python_node(temp_dir.path(), "package_1", "node_123", false);
 
     QString node_path = QDir(temp_dir.path()).filePath("package_1/package_1/node_123.py");
     QString contents = read_file(node_path);

--- a/turtle_nest_tests/tst_ros_pkg_creator.cpp
+++ b/turtle_nest_tests/tst_ros_pkg_creator.cpp
@@ -25,8 +25,6 @@
 #include <QRegularExpression>
 #include <QProcess>
 #include <QTimer>
-#include <QCoreApplication>
-#include <QObject>
 #include <QDateTime>
 #include <QStringList>
 #include <QElapsedTimer>

--- a/turtle_nest_tests/tst_ros_pkg_creator.cpp
+++ b/turtle_nest_tests/tst_ros_pkg_creator.cpp
@@ -17,15 +17,29 @@
 
 #include <gmock/gmock-matchers.h>
 #include <gtest/gtest.h>
-#include <turtle_nest/rospkgcreator.h>
+#include "turtle_nest/rospkgcreator.h"
+#include "turtle_nest/file_utils.h"
 #include <QDebug>
 #include <QTemporaryDir>
 #include <QXmlStreamReader>
 #include <QRegularExpression>
+#include <QProcess>
+#include <QTimer>
+#include <QCoreApplication>
+#include <QObject>
+#include <QDateTime>
+#include <QStringList>
+#include <QElapsedTimer>
+#include <QThread>
 
 
 using namespace testing;
 
+
+const QString python_node_text = "[python_node]: Hello world from the Python node python_node";
+const QString python_param_text = "[python_node]: Declared parameter 'example_param'. Value: abc";
+const QString cpp_node_text = "[cpp_node]: Hello world from the C++ node cpp_node";
+const QString cpp_param_text = "[cpp_node]: Declared parameter 'example_param'. Value: abc";
 
 bool file_exists(QString path) {
     QFile file(path);
@@ -109,6 +123,74 @@ bool dir_is_empty(const QString& dirPath) {
     return files.isEmpty();
 }
 
+QString run_command(QString command, QStringList outputs_to_wait, QString workspace_path = ""){
+    QDateTime current_date_time = QDateTime::currentDateTime();
+    qint64 timestamp_seconds = current_date_time.toSecsSinceEpoch();
+    qint64 timestamp_ms = current_date_time.toMSecsSinceEpoch();
+    QString formatted_time = QString("[%1.%2]")
+                                  .arg(timestamp_seconds)
+                                  .arg(timestamp_ms % 1000, 3, 10, QChar('0'));
+
+    QProcess *process = new QProcess();
+    process->setProcessChannelMode(QProcess::MergedChannels);
+
+    // Source the workspace if given
+    if (!workspace_path.isEmpty()) {
+        QDir dir(workspace_path);
+        dir.cdUp(); // Get the path without /src extension
+        command = QString("source %1/install/setup.bash && %2").arg(dir.path(), command);
+    }
+
+    qDebug().noquote() << formatted_time << "Running:" << "bash -c" << command;
+    process->start("bash", QStringList() << "-c" << command);
+
+    // Wait for the command to execute until all "outputs_to_wait" strings are found from the output
+    QElapsedTimer timer;
+    timer.start();
+
+    QString output;
+    while (!outputs_to_wait.isEmpty() && timer.elapsed() < 30000) {
+        if (!process->waitForReadyRead(100)) {
+            continue;
+        }
+        QString new_output = process->readAllStandardOutput();
+        output += new_output;
+        qDebug().noquote() << new_output;
+
+        // Check if any expected output is found in the output
+        for (int i = 0; i < outputs_to_wait.size(); ) {
+            if (output.contains(outputs_to_wait[i])) {
+                outputs_to_wait.removeAt(i);
+            } else {
+                ++i;
+            }
+        }
+    }
+
+    if (outputs_to_wait.isEmpty()){
+        qDebug() << "Found all the expected lines";
+    } else {
+        qDebug() << "Timed out while waiting for the expected lines";
+    }
+
+    // Sending SIGINT very soon after the launch was started will make the process hang. Wait for a second before doing that.
+    qDebug() << "Sending SIGINT";
+    QThread::sleep(1);
+    kill(process->processId(), SIGINT);
+
+    if (!process->waitForFinished(20000)) {
+        // If it still didn't finish, terminate
+        qCritical() << "Process didn't finish with SIGINT. Terminating. This might leave active background processes";
+        process->terminate();
+    }
+
+    QString new_output = process->readAllStandardOutput();
+    output += new_output;
+    qDebug().noquote() << new_output;
+
+    return output;
+}
+
 
 // Test the package creation with default parameters
 TEST(ros_pkg_creator, create_pkg_defaults){
@@ -145,6 +227,9 @@ TEST(ros_pkg_creator, create_pkg_all_values){
     ASSERT_EQ("multi-line test \n description", read_xml_tag(xml_path, "description"));
     ASSERT_EQ("maintainer@admin.com", read_xml_tag(xml_path, "maintainer", "email"));
 
+    QString output = run_command("ros2 launch package_name demo_launch.py", {python_node_text, cpp_node_text}, pkg_creator.workspace_path);
+    ASSERT_TRUE(output.contains(python_node_text));
+    ASSERT_TRUE(output.contains(cpp_node_text));
 }
 
 // Try to create a package to destination the user doesn't have access rights
@@ -167,9 +252,13 @@ TEST(ros_pkg_creator, cpp_no_node){
 TEST(ros_pkg_creator, cpp_with_node){
     RosPkgCreator pkg_creator(get_tmp_workspace_path(), "package_name", CPP);
     pkg_creator.node_name_cpp = "cpp_node";
+    pkg_creator.launch_name = "test_launch";
     pkg_creator.create_package();
     pkg_creator.build_package();
     ASSERT_TRUE(file_exists(pkg_creator.package_path + "/src/cpp_node.cpp"));
+
+    QString output = run_command("ros2 launch package_name test_launch.py", {cpp_node_text}, pkg_creator.workspace_path);
+    ASSERT_TRUE(output.contains(cpp_node_text));
 }
 
 // Create a Python package without a Node
@@ -185,6 +274,7 @@ TEST(ros_pkg_creator, python_no_node){
 TEST(ros_pkg_creator, python_with_node){
     RosPkgCreator pkg_creator(get_tmp_workspace_path(), "package_name", PYTHON);
     pkg_creator.node_name_python = "python_node";
+    pkg_creator.launch_name = "test_launch";
     pkg_creator.create_package();
     pkg_creator.build_package();
     ASSERT_TRUE(file_exists(pkg_creator.package_path + "/package_name/__init__.py"));
@@ -193,6 +283,9 @@ TEST(ros_pkg_creator, python_with_node){
         (pkg_creator.package_path + "/package_name/python_node.py"),
         "Hello world from the Python node python_node"
     ));
+
+    QString output = run_command("ros2 launch package_name test_launch.py", {python_node_text}, pkg_creator.workspace_path);
+    ASSERT_TRUE(output.contains(python_node_text));
 }
 
 // Create a CPP+Python package without Nodes
@@ -208,16 +301,21 @@ TEST(ros_pkg_creator, cpp_python_no_nodes){
 TEST(ros_pkg_creator, cpp_python_with_cpp_node){
     RosPkgCreator pkg_creator(get_tmp_workspace_path(), "package_name", CPP_AND_PYTHON);
     pkg_creator.node_name_cpp = "cpp_node";
+    pkg_creator.launch_name = "test_launch";
     pkg_creator.create_package();
     pkg_creator.build_package();
     ASSERT_TRUE(file_exists(pkg_creator.package_path + "/src/cpp_node.cpp"));
     ASSERT_TRUE(file_exists(pkg_creator.package_path + "/package_name/__init__.py"));
+
+    QString output = run_command("ros2 launch package_name test_launch.py", {cpp_node_text}, pkg_creator.workspace_path);
+    ASSERT_TRUE(output.contains(cpp_node_text));
 }
 
 // Create a CPP+Python package with Python Node
 TEST(ros_pkg_creator, cpp_python_with_python_node){
     RosPkgCreator pkg_creator(get_tmp_workspace_path(), "package_name", CPP_AND_PYTHON);
     pkg_creator.node_name_python = "python_node";
+    pkg_creator.launch_name = "test_launch";
     pkg_creator.create_package();
     pkg_creator.build_package();
     ASSERT_TRUE(dir_is_empty(pkg_creator.package_path + "/src"));
@@ -227,6 +325,9 @@ TEST(ros_pkg_creator, cpp_python_with_python_node){
         (pkg_creator.package_path + "/package_name/python_node.py"),
         "Hello world from the Python node python_node"
         ));
+
+    QString output = run_command("ros2 launch package_name test_launch.py", {python_node_text}, pkg_creator.workspace_path);
+    ASSERT_TRUE(output.contains(python_node_text));
 }
 
 
@@ -235,6 +336,7 @@ TEST(ros_pkg_creator, cpp_python_with_both_nodes){
     RosPkgCreator pkg_creator(get_tmp_workspace_path(), "package_name", CPP_AND_PYTHON);
     pkg_creator.node_name_cpp = "cpp_node";
     pkg_creator.node_name_python = "python_node";
+    pkg_creator.launch_name = "test_launch";
     pkg_creator.create_package();
     pkg_creator.build_package();
     ASSERT_TRUE(file_exists(pkg_creator.package_path + "/src/cpp_node.cpp"));
@@ -244,6 +346,121 @@ TEST(ros_pkg_creator, cpp_python_with_both_nodes){
         (pkg_creator.package_path + "/package_name/python_node.py"),
         "Hello world from the Python node python_node"
         ));
+
+    QStringList outputs_to_wait = {python_node_text, cpp_node_text};
+    QString output = run_command(QString("ros2 launch package_name test_launch.py"), outputs_to_wait, pkg_creator.workspace_path);
+    for (const QString &expected : outputs_to_wait) {
+        ASSERT_TRUE(output.contains(expected));
+    }
+}
+
+// /*
+//  * TEST PARAMS FILE
+// */
+
+// Test that an empty params file is created when package with no Nodes is created (CPP package)
+TEST(ros_pkg_creator, test_params_with_no_nodes_cpp) {
+    RosPkgCreator pkg_creator(get_tmp_workspace_path(), "test_package", CPP);
+    pkg_creator.launch_name = "test_launch";
+    pkg_creator.params_file_name = "test_params";
+    pkg_creator.create_package();
+    pkg_creator.build_package();
+
+    QString output = run_command(QString("ros2 launch test_package test_launch.py"), {"[INFO] [launch]:"}, pkg_creator.workspace_path);
+
+    ASSERT_TRUE(!output.contains(python_param_text));
+    ASSERT_TRUE(!output.contains(cpp_param_text));
+
+    QString params_path = QString(pkg_creator.package_path + "/config/test_params.yaml");
+    ASSERT_TRUE(file_exists(params_path));
+    ASSERT_EQ(read_file(params_path), "");
+
+    ASSERT_TRUE(string_exists_in_file((pkg_creator.package_path + "/CMakeLists.txt"), "# Install config files"));
+}
+
+// Test that an empty params file is created when package with no Nodes is created (Python package)
+TEST(ros_pkg_creator, test_params_with_no_nodes_python) {
+    RosPkgCreator pkg_creator(get_tmp_workspace_path(), "test_package", PYTHON);
+    pkg_creator.launch_name = "test_launch";
+    pkg_creator.params_file_name = "test_params";
+    pkg_creator.create_package();
+    pkg_creator.build_package();
+
+    QString output = run_command(QString("ros2 launch test_package test_launch.py"), {"[INFO] [launch]:"}, pkg_creator.workspace_path);
+
+    ASSERT_TRUE(!output.contains(python_param_text));
+    ASSERT_TRUE(!output.contains(cpp_param_text));
+
+    QString params_path = QString(pkg_creator.package_path + "/config/test_params.yaml");
+    ASSERT_TRUE(file_exists(params_path));
+    ASSERT_EQ(read_file(params_path), "");
+
+    ASSERT_TRUE(string_exists_in_file((pkg_creator.package_path + "/setup.py"), "(os.path.join('share', package_name, 'config'), glob('config/*.yaml')),"));
+}
+
+// Test the params file creation with both Python Package and Node
+TEST(ros_pkg_creator, test_params_with_python_node) {
+    RosPkgCreator pkg_creator(get_tmp_workspace_path(), "test_package", PYTHON);
+    pkg_creator.node_name_python = "python_node";
+    pkg_creator.launch_name = "test_launch";
+    pkg_creator.params_file_name = "test_params";
+    pkg_creator.create_package();
+    pkg_creator.build_package();
+
+    QStringList outputs_to_wait = {python_node_text, python_param_text};
+    QString output = run_command(QString("ros2 launch test_package test_launch.py"), outputs_to_wait, pkg_creator.workspace_path);
+
+    for (const QString &expected : outputs_to_wait) {
+        ASSERT_TRUE(output.contains(expected));
+    }
+
+    ASSERT_TRUE(!output.contains(cpp_node_text));
+    ASSERT_TRUE(!output.contains(cpp_param_text));
 }
 
 
+// Test the params file creation with both CPP and Python Nodes
+TEST(ros_pkg_creator, test_params_with_both_nodes) {
+    RosPkgCreator pkg_creator(get_tmp_workspace_path(), "test_package", CPP_AND_PYTHON);
+    pkg_creator.node_name_cpp = "cpp_node";
+    pkg_creator.node_name_python = "python_node";
+    pkg_creator.launch_name = "test_launch";
+    pkg_creator.params_file_name = "test_params";
+    pkg_creator.create_package();
+    pkg_creator.build_package();
+
+    QStringList outputs_to_wait = {python_node_text, cpp_node_text, python_param_text, cpp_param_text};
+    QString output = run_command(QString("ros2 launch test_package test_launch.py"), outputs_to_wait, pkg_creator.workspace_path);
+
+    for (const QString &expected : outputs_to_wait) {
+        ASSERT_TRUE(output.contains(expected));
+    }
+}
+
+// Test that the params file is not created and the launch file is correctly populated when params_file_name is empty
+TEST(ros_pkg_creator, test_params_not_set) {
+    RosPkgCreator pkg_creator(get_tmp_workspace_path(), "test_package", CPP_AND_PYTHON);
+    pkg_creator.node_name_cpp = "cpp_node";
+    pkg_creator.node_name_python = "python_node";
+    pkg_creator.launch_name = "test_launch";
+    pkg_creator.create_package();
+    pkg_creator.build_package();
+
+    QStringList outputs_to_wait = {python_node_text, cpp_node_text};
+
+    QString output = run_command(QString("ros2 launch test_package test_launch.py"), outputs_to_wait, pkg_creator.workspace_path);
+
+    for (const QString &expected : outputs_to_wait) {
+        ASSERT_TRUE(output.contains(expected));
+    }
+
+    ASSERT_TRUE(!output.contains(python_param_text));
+    ASSERT_TRUE(!output.contains(cpp_param_text));
+
+    QString params_path = QString(pkg_creator.package_path + "/config/test_params.yaml");
+    ASSERT_TRUE(!file_exists(params_path));
+
+    // Confirm that parameters are empty in the launch file
+    ASSERT_TRUE(string_exists_in_file((pkg_creator.workspace_path + "/test_package" + "/launch/" + pkg_creator.launch_name + ".py"), "parameters=[]"));
+
+}

--- a/turtle_nest_tests/turtle_nest_tests.pro
+++ b/turtle_nest_tests/turtle_nest_tests.pro
@@ -15,7 +15,10 @@ SOURCES += \
         ../turtle_nest/src/file_utils.cpp \
         ../turtle_nest/src/generate_node.cpp \
         ../turtle_nest/src/rospkgcreator.cpp \
+        ../turtle_nest/src/generate_cmake.cpp \
         ../turtle_nest/src/generate_launch.cpp \
+        ../turtle_nest/src/generate_params.cpp \
+        ../turtle_nest/src/generate_setup_py.cpp \
         ../turtle_nest/src/string_tools.cpp
 
 INCLUDEPATH += ../turtle_nest/include/


### PR DESCRIPTION
- New feature: Easily add a new parameters file during the package creation. An example parameter is set for each generated node (Python and CPP).

In addition:
- Added "ros2 launch" step for tests to automatically verify that things work as expected in all the Distros
- Tests are now ran in parallel for different ROS distros, making running checks faster
- Colcon test is now also ran for Humble distro (uncrustify works differently in Humble and Rolling)
- Docker containers now use the default "rmw_fastrtps_cpp" DDS, due to a problem with Node launching in Rolling with CycloneDDS


Resolves #7 