### PR TITLE
Replace ament_target_dependencies with target_link_libraries

### DIFF
--- a/turtle_nest/CMakeLists.txt
+++ b/turtle_nest/CMakeLists.txt
@@ -71,9 +71,6 @@ endforeach()
 
 
 target_compile_features(turtle_nest PUBLIC c_std_99 cxx_std_17)  # Require C99 and C++17
-ament_target_dependencies(
-  turtle_nest
-)
 
 install(TARGETS turtle_nest
   DESTINATION lib/${PROJECT_NAME})


### PR DESCRIPTION
`ament_target_dependencies` is deprecated on `kilted` and removed in `rolling`,  It will require a new release on `rolling`.


Debs are broken https://build.ros2.org/view/Rbin_uN64/job/Rbin_uN64__turtle_nest__ubuntu_noble_amd64__binary/