### PR TITLE
Fix black dependency

### DIFF
--- a/turtle_nest/package.xml
+++ b/turtle_nest/package.xml
@@ -18,7 +18,7 @@
   <build_depend>qtbase5-dev</build_depend>
   <build_depend>libqt5-svg-dev</build_depend>
 
-  <build_depend>black</build_depend>
+  <exec_depend>black</exec_depend>
   <exec_depend>libqt5-core</exec_depend>
   <exec_depend>libqt5-gui</exec_depend>
   <exec_depend>libqt5-opengl</exec_depend>


### PR DESCRIPTION
This was causing Python package creation to fail if black wasn't installed. After this, black should come automatically when installing via apt.