### PR TITLE
Fix Python package multi-line descriptions

### DIFF
--- a/turtle_nest/src/string_tools.cpp
+++ b/turtle_nest/src/string_tools.cpp
@@ -27,6 +27,8 @@ QString escape_xml(const QString input)
   output.replace(">", "&gt;");
   output.replace("\"", "");    // Quotation marks are just removed
   output.replace("'", "&apos;");
+  output.replace("\n", "&#10;");   // Replace newline. Needed for Python setup.py files, as they'll otherwise break.
+  output.replace("\r", "&#13;");   // Replace carriage return. Newlines not supported in Python setup.py files, carriage return might be used on Windows or Mac for newlines
   return output;
 }
 

--- a/turtle_nest_tests/tst_package_creation.cpp
+++ b/turtle_nest_tests/tst_package_creation.cpp
@@ -98,11 +98,7 @@ TEST(package_creation, create_pkg_all_values) {
   for (BuildType build_type: get_build_types()) {
     QString package_name = build_type_to_string(build_type);
     PackageInfo pkg_info(package_name, get_tmp_package_dest(), build_type);
-    pkg_info.description = "multi-line test \n description";
-    if (build_type == BuildType::PYTHON){
-      //TODO: https://github.com/Jannkar/turtle_nest/issues/33
-      pkg_info.description = "single-line description";
-    }
+    pkg_info.description = "multi-line test \n description"; // Test also multi-line description validity.
     pkg_info.maintainer = "Test Maintainer";
     pkg_info.maintainer_email = "maintainer@admin.com";
     pkg_info.license = "Apache-2.0";


### PR DESCRIPTION
Line changes for package description were breaking the setup.py file when compiling. This PR encodes the newlines for setup.py.

Fixes #33 